### PR TITLE
Remove ::Function annotations

### DIFF
--- a/src/krawczyk.jl
+++ b/src/krawczyk.jl
@@ -7,7 +7,7 @@
 doc"""Returns two intervals, the first being a point within the
 interval x such that the interval corresponding to the derivative of f there
 does not contain zero, and the second is the inverse of its derivative"""
-function guarded_derivative_midpoint{T}(f::Function, f_prime::Function, x::Interval{T})
+function guarded_derivative_midpoint{T}(f, f_prime, x::Interval{T})
 
     α = convert(T, 0.46875)   # close to 0.5, but exactly representable as a floating point
     # m = Interval( guarded_mid(f, x) )
@@ -31,7 +31,7 @@ function guarded_derivative_midpoint{T}(f::Function, f_prime::Function, x::Inter
 end
 
 
-function K{T}(f::Function, f_prime::Function, x::Interval{T})
+function K{T}(f, f_prime, x::Interval{T})
     m, C = guarded_derivative_midpoint(f, f_prime, x)
     deriv = f_prime(x)
     Kx = m - C*f(m) + (one(T) - C*deriv) * (x - m)
@@ -39,7 +39,7 @@ function K{T}(f::Function, f_prime::Function, x::Interval{T})
 end
 
 
-function krawczyk_refine{T}(f::Function, f_prime::Function, x::Interval{T};
+function krawczyk_refine{T}(f, f_prime, x::Interval{T};
     tolerance=eps(one(T)), debug=false)
 
     debug && (print("Entering krawczyk_refine:"); @show x)
@@ -58,7 +58,7 @@ end
 
 
 
-function krawczyk{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=0;
+function krawczyk{T}(f, f_prime, x::Interval{T}, level::Int=0;
     tolerance=eps(one(T)), debug=false, maxlevel=30)
 
     debug && (print("Entering krawczyk:"); @show(level); @show(x))
@@ -98,15 +98,15 @@ end
 
 
 # use automatic differentiation if no derivative function given
-krawczyk{T}(f::Function,x::Interval{T}; args...) =
+krawczyk{T}(f,x::Interval{T}; args...) =
     krawczyk(f, x->D(f,x), x; args...)
 
 # krawczyk for vector of intervals:
-krawczyk{T}(f::Function, f_prime::Function, xx::Vector{Interval{T}}; args...) =
+krawczyk{T}(f, f_prime, xx::Vector{Interval{T}}; args...) =
     vcat([krawczyk(f, f_prime, @interval(x); args...) for x in xx]...)
 
-krawczyk{T}(f::Function,  xx::Vector{Interval{T}}, level; args...) =
+krawczyk{T}(f,  xx::Vector{Interval{T}}, level; args...) =
     krawczyk(f, x->D(f,x), xx; args...)
 
-krawczyk{T}(f::Function,  xx::Vector{Root{T}}; args...) =
+krawczyk{T}(f,  xx::Vector{Root{T}}; args...) =
     krawczyk(f, x->D(f,x), [x.interval for x in xx]; args...)

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -29,7 +29,7 @@ end
 
 doc"""If a root is known to be inside an interval,
 `newton_refine` iterates the interval Newton method until that root is found."""
-function newton_refine{T}(f::Function, f_prime::Function, x::Interval{T};
+function newton_refine{T}(f, f_prime, x::Interval{T};
                           tolerance=eps(T), debug=false)
 
     debug && (print("Entering newton_refine:"); @show x)
@@ -59,7 +59,7 @@ with its optional derivative `f_prime` and initial interval `x`.
 Optional keyword arguments give the `tolerance`, `maxlevel` at which to stop
 subdividing, and a `debug` boolean argument that prints out diagnostic information."""
 
-function newton{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=0;
+function newton{T}(f, f_prime, x::Interval{T}, level::Int=0;
                    tolerance=eps(T), debug=false, maxlevel=30)
 
     debug && (print("Entering newton:"); @show(level); @show(x))
@@ -137,15 +137,15 @@ end
 
 
 # use automatic differentiation if no derivative function given:
-newton{T}(f::Function, x::Interval{T};  args...) =
+newton{T}(f, x::Interval{T};  args...) =
     newton(f, x->D(f,x), x; args...)
 
 # newton for vector of intervals:
-newton{T}(f::Function, f_prime::Function, xx::Vector{Interval{T}}; args...) =
+newton{T}(f, f_prime, xx::Vector{Interval{T}}; args...) =
     vcat([newton(f, f_prime, @interval(x); args...) for x in xx]...)
 
-newton{T}(f::Function,  xx::Vector{Interval{T}}, level; args...) =
+newton{T}(f,  xx::Vector{Interval{T}}, level; args...) =
     newton(f, x->D(f,x), xx, 0, args...)
 
-newton{T}(f::Function,  xx::Vector{Root{T}}; args...) =
+newton{T}(f,  xx::Vector{Root{T}}; args...) =
     newton(f, x->D(f,x), [x.interval for x in xx], args...)


### PR DESCRIPTION
One can sensibly find roots of callable objects that aren't necessarily <:Function. Unless such things really should be <:Function?